### PR TITLE
Refactor chat history to MongoDB per user+chat_id, remove global memory

### DIFF
--- a/backend/src/ai_model/rag_cloud.py
+++ b/backend/src/ai_model/rag_cloud.py
@@ -3,7 +3,7 @@ from .vectorstore import initialize_vectorstore
 
 from langchain_google_genai import GoogleGenerativeAIEmbeddings, ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.chat_history import InMemoryChatMessageHistory
+from langchain_core.messages import HumanMessage, AIMessage, SystemMessage, BaseMessage
 
 # ----------------------------- 
 # 1) Embeddings + Vectorstore 
@@ -20,19 +20,19 @@ vectorstore = initialize_vectorstore(embeddings, settings.PERSIST_DIRECTORY, set
 # -----------------------------
 
 llm = ChatGoogleGenerativeAI(
-    model='gemini-2.0-flash-001', # Gemini 2.0 Flash
-    temperature=0.3, # Alustava lämpötila
-    max_tokens=1000,    # nostettu 500 -> 1000
+    model='gemini-2.0-flash-001',  # Gemini 2.0 Flash
+    temperature=0.3,              # Alustava lämpötila
+    max_tokens=1000,              # nostettu 500 -> 1000
     top_p=0.9,
     google_api_key=settings.GOOGLE_API_KEY
 )
 
-# Alustetaan keskustelumuisti
-memory = InMemoryChatMessageHistory()
-
 system_prompt = (
     "You are an assistant for question-answering tasks. "
     "Use the following pieces of retrieved context and chat history to answer the question. "
+    "Always check both the retrieved context and the provided chat history before deciding that you do not have enough information. "
+    "If the answer is present in the chat history, answer based on it. "
+    "You do have access to the provided chat history and must not claim otherwise. "
     "Do not use any outside knowledge or make assumptions. "
     "Determine first whether the question is in Finnish or English, and respond in the same language. "
 
@@ -52,8 +52,35 @@ system_prompt = (
 
     "\n\n"
     "Context: {context}\n\n"
-    "Chat history: {chat_history}"
 )
+
+def mongo_docs_to_lc_messages(docs: list[dict]) -> list[BaseMessage]:
+    """
+    Muuntaa MongoDB:stä haetut chat-viestit LangChainin viestiolioiksi.
+    Odottaa docs-listan olevan aikajärjestyksessä (vanhin -> uusin).
+
+    HUOM: yhteensopivuus T:n kanssa:
+      sender: "user" | "bot" | "professional" | (mahd. "system")
+    """
+    messages: list[BaseMessage] = []
+    for d in docs:
+        sender = d.get("sender")
+        content = d.get("content", "")
+
+        if not content:
+            continue
+
+        if sender == "user":
+            messages.append(HumanMessage(content=content))
+        elif sender == "bot":
+            messages.append(AIMessage(content=content))
+        elif sender == "professional":
+            # Ammattilainen käsitellään ihmisenä LLM:lle
+            messages.append(HumanMessage(content=content))
+        elif sender == "system":
+            messages.append(SystemMessage(content=content))
+
+    return messages
 
 prompt = ChatPromptTemplate.from_messages(
     [
@@ -75,12 +102,12 @@ async def retrieve_with_fallback(user_input: str, vectorstore, top_k: int = 6, s
     Palauttaa listan relevantteja dokumentteja.
     """
 
-     # Threshold-haku
+    # Threshold-haku
     retriever = vectorstore.as_retriever(
-        search_type="similarity_score_threshold", # Vain dokumentit, jotka ovat riittävän lähellä käyttäjän kysymystä, otetaan mukaan.
-        search_kwargs={"k": top_k, "score_threshold": score_threshold} # Kysytään 6 eniten samankaltaista dokumenttia, joista vain ne, joiden samankaltaisuus on yli 0.6, otetaan mukaan.
-    )   
-    
+        search_type="similarity_score_threshold",  # Vain dokumentit, jotka ovat riittävän lähellä käyttäjän kysymystä, otetaan mukaan.
+        search_kwargs={"k": top_k, "score_threshold": score_threshold}  # Kysytään 6 eniten samankaltaista dokumenttia, joista vain ne, joiden samankaltaisuus on yli 0.6, otetaan mukaan.
+    )
+
     relevant_docs = await retriever.ainvoke(user_input)
 
     # Fallback tarvittaessa
@@ -88,7 +115,7 @@ async def retrieve_with_fallback(user_input: str, vectorstore, top_k: int = 6, s
         print("⚠️ Ei tarpeeksi relevantteja osumia threshold-hausta – otetaan käyttöön fallback MMR...")
         fallback_retriever = vectorstore.as_retriever(
             search_type="mmr",
-            search_kwargs={"k": fallback_k}#, "fetch_k": 20, "lambda_mult": 0.5}
+            search_kwargs={"k": fallback_k}  # , "fetch_k": 20, "lambda_mult": 0.5}
         )
         relevant_docs = await fallback_retriever.ainvoke(user_input)
 
@@ -97,35 +124,24 @@ async def retrieve_with_fallback(user_input: str, vectorstore, top_k: int = 6, s
 # -----------------------------
 # 4) Julkaistava funktio, jolla saa RAG-vastauksen
 # -----------------------------
-async def get_rag_response(user_input: str) -> str:
+async def get_rag_response(user_input: str, chat_history_docs: list[dict]) -> str:
     """
     Kysyy RAG-ketjulta (Chroma+GEMINI) ja palauttaa vastauksen tekstinä.
+    Chat history tulee ulkoa (MongoDB), ei globaalista muistista.
     """
-    memory.add_user_message(user_input)
+    chat_history = mongo_docs_to_lc_messages(chat_history_docs)
 
-     # Hae dokumentit threshold + fallback -logiikalla
+    # Hae dokumentit threshold + fallback -logiikalla
     relevant_docs = await retrieve_with_fallback(user_input, vectorstore)
 
-    if not relevant_docs:
-        no_info_msg = (
-            "Valitettavasti minulla ei ole riittävästi tietoa kysymääsi aiheeseen. "
-            "Suosittelen ottamaan yhteyttä asiantuntijaan tai hoitavaan tahoon."
-        )
-        memory.add_ai_message(no_info_msg)
-        return no_info_msg
+    context_str = ""
+    if relevant_docs:
+        context_str = "\n\n---\n\n".join([d.page_content for d in relevant_docs])
 
-    # Vastauksen generointi (asynkronisesti)
-    response = await rag_chain.ainvoke({ 
-        "context": relevant_docs, 
-        "chat_history": memory.messages, 
-        "input": user_input 
+    response = await rag_chain.ainvoke({
+        "context": context_str,
+        "chat_history": chat_history,
+        "input": user_input
     })
 
-    memory.add_ai_message(response.content)
-    print(f"Chat memory: {memory.messages}")
-
     return response.content
-
-def clear_conversation_memory():
-    # Tyhjentää keskustelumuistin
-    memory.clear()

--- a/backend/src/database/chat_store.py
+++ b/backend/src/database/chat_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional, Dict, Any, Literal
+
+from database.db import messages_collection
+
+Sender = Literal["user", "bot", "professional"]
+Classification = Literal["safe", "needs_review", "emergency"]
+
+async def save_message(
+    *,
+    user_id: str,
+    chat_id: str,
+    sender: Sender,
+    content: str,
+    classification: Classification = "safe",
+    flagged_for_human: bool = False,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    if not content:
+        return
+
+    now = datetime.now(timezone.utc)
+    doc: Dict[str, Any] = {
+        "user_id": user_id,          # pidä demossa erottelu varmistuksena
+        "chat_id": chat_id,
+        "sender": sender,            # T-yhteensopiva
+        "content": content,
+        "classification": classification,
+        "flagged_for_human": flagged_for_human,
+        "created_at": now,
+        "updated_at": now,
+    }
+    if metadata:
+        doc["metadata"] = metadata
+
+    await messages_collection.insert_one(doc)
+
+
+async def get_recent_messages(
+    *,
+    user_id: str,
+    chat_id: str,
+    limit: int = 20,
+) -> List[Dict[str, Any]]:
+    if limit <= 0:
+        return []
+
+    cursor = (
+        messages_collection
+        .find({"user_id": user_id, "chat_id": chat_id})
+        .sort("created_at", -1)
+        .limit(limit)
+    )
+    docs = await cursor.to_list(length=limit)
+    docs.reverse()
+    return docs
+
+
+async def delete_chat_messages(*, user_id: str, chat_id: str) -> int:
+    result = await messages_collection.delete_many({"user_id": user_id, "chat_id": chat_id})
+    return int(result.deleted_count)

--- a/backend/src/database/db.py
+++ b/backend/src/database/db.py
@@ -30,16 +30,19 @@ logger.info(f"Loaded MONGO_URI: {MONGO_URI}")
 client = None
 db = None
 users_collection = None
+chat_messages_collection = None
 
 # Connect to MongoDB
 try:
     client = AsyncIOMotorClient(MONGO_URI)
     db = client["chatbot_database"] 
     users_collection = db["users"]
+    messages_collection = db["messages"]
+    chat_messages_collection = messages_collection
     logger.info("✅ Successfully connected to MongoDB!")
 except Exception as e:
     logger.error(f"❌ ERROR: Failed to connect to MongoDB: {e}")
     raise
 
 # Expose db and users_collection for other modules
-__all__ = ["db", "users_collection"]
+__all__ = ["db", "users_collection", "messages_collection", "chat_messages_collection"]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,11 +1,17 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
 # Haetaan kirjautuneen käyttäjän tiedot ja kirjautumisen tila
 from routes.users import router as user_router, current_user_id, logged_in
+
 from ai_model import rag_cloud
 from ai_model import utils
+
 from bson import ObjectId
+from uuid import uuid4
+
 from database.db import users_collection
+from database.chat_store import get_recent_messages, save_message
 
 
 app = FastAPI()
@@ -15,11 +21,10 @@ app.state.logged_in = False
 app.state.current_user_id = None
 app.state.current_user_data = None
 
-
 # CORS (Allow frontend to communicate with backend)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -29,55 +34,66 @@ app.add_middleware(
 def home():
     return {"message": "Hello from FastAPI!"}
 
+
 @app.post("/api/send")
 async def send_message(payload: dict):
     """
-    1) Lukee frontendiltä tulevan 'message' ja (optionaalisen) 'user_id' -kentän.
-    2) Jos user_id on annettu ja kelvollinen, hakee käyttäjädatan MongoDB:stä.
-    3) Yhdistää käyttäjädatan promtiin ja kutsuu RAG-mallia.
+    1) Lukee frontendiltä tulevan 'message' ja (optionaalisen) 'chat_id' -kentän.
+    2) Hakee keskusteluhistorian MongoDB:stä user_id + chat_id perusteella.
+    3) Tallentaa user-viestin MongoDB:hen.
+    4) (Optionaalisesti) hakee patient_info jos logged_in ja user_id on valid ObjectId.
+    5) Kutsuu RAG-mallia (historia mukana).
+    6) Tallentaa bot-viestin MongoDB:hen.
+    7) Palauttaa reply + chat_id.
     """
-    
-    logged_in = app.state.logged_in 
+    logged_in_state = app.state.logged_in
 
-    # Muutettu käyttämään payloadia, requestin sijaan
     user_message = payload.get("message")
-    user_id = app.state.current_user_id
+    chat_id = payload.get("chat_id") or str(uuid4())
 
-    # jos haluaa muuttaa niin voi hakea user_datan suoraan globaalista muuttujasta ja käyttää sitä
-    # nyt data haetaan ensin MongoDB:stä ja sitten asetetaan globaaliksi muuttujaksi
-    # ja uudelleen sama tässä mainissa
+    user_id = app.state.current_user_id or "guest"
 
     if not user_message:
         raise HTTPException(status_code=400, detail="Message is required.")
 
-    # 1) Haetaan käyttäjädata, jos user_id on annettu
+    # 1) Hae viimeisimmät viestit tästä chatista
+    history_docs = await get_recent_messages(user_id=user_id, chat_id=chat_id, limit=20)
+
+    # 2) Tallenna user-viesti (T-yhteensopiva sender)
+    await save_message(user_id=user_id, chat_id=chat_id, sender="user", content=user_message)
+
+    # 3) Rakennetaan prompt (patient_info mukaan vain jos logged_in ja user_id valid)
+    prompt = user_message
+
     user_data = None
-    if user_id:
-        if not ObjectId.is_valid(user_id):
-            raise HTTPException(status_code=400, detail="Invalid user_id format.")
+    if logged_in_state and user_id != "guest" and ObjectId.is_valid(user_id):
         user_doc = await users_collection.find_one({"_id": ObjectId(user_id)})
         if user_doc:
-            user_doc["_id"] = str(user_doc["_id"])  # Muunnetaan _id stringiksi
+            user_doc["_id"] = str(user_doc["_id"])
             user_data = user_doc
 
-    # 2) Rakennetaan prompt, jossa lisätään käyttäjädata mukaan
-    if logged_in:
-        if user_data:
-            prompt = f"{user_message}\n\nUser data:\n{user_data}"
-        else:
-            prompt = user_message
-    else:
-        prompt = user_message
+    # liitetään vain patient_info, ei koko user-dataa
+    if logged_in_state and user_data and user_data.get("patient_info"):
+        patient_info = user_data["patient_info"]
+        prompt = f"{user_message}\n\nPatient info:\n{patient_info}"
 
-    # 3) Kutsutaan RAG-mallia
+    # 4) Kutsu RAG-mallia chat-historialla (lisätään myös juuri tullut user-viesti historiaan)
+    history_plus_latest = history_docs + [{"sender": "user", "content": user_message}]
+
     try:
-        raw_response = await rag_cloud.get_rag_response(prompt)
+        raw_response = await rag_cloud.get_rag_response(prompt, history_plus_latest)
         formatted_text = utils.formatGeminiResponse(raw_response)
-        return {"reply": formatted_text}
+
+        # 5) Tallenna bot-vastaus
+        await save_message(user_id=user_id, chat_id=chat_id, sender="bot", content=raw_response)
+
+        return {"reply": formatted_text, "chat_id": chat_id}
+
     except Exception as e:
         import traceback
-        traceback.print_exc()  # Näyttää tarkemman syyn konsolissa
+        traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
+
 
 # Register user routes
 app.include_router(user_router, prefix="/users", tags=["users"])

--- a/frontend/src/components/Chat.vue
+++ b/frontend/src/components/Chat.vue
@@ -55,7 +55,7 @@
 <script>
 import axios from "axios";
 import PatientForm from "./PatientForm.vue";
-import { useI18n } from "vue-i18n"; // Lisätty kielituki
+import { useI18n } from "vue-i18n";
 
 export default {
   name: "ChatComponent",
@@ -66,23 +66,34 @@ export default {
     externalShowForm: Boolean,
   },
   setup() {
-    const { t, locale } = useI18n(); // Hae kielituki
+    const { t, locale } = useI18n();
     return { t, locale };
   },
   data() {
     return {
       userId: "user123",
+      chatId: null,
       messages: [],
       newMessage: "",
       showForm: false,
-      welcomeMessageDisplayed: true, // Tervetuloviesti näytetään vain kerran
+      welcomeMessageDisplayed: true,
     };
   },
+
+  mounted() {
+    // Palauta aiempi chat_id (jos olemassa), jotta keskustelu jatkuu refreshin jälkeen
+    const storedChatId = localStorage.getItem("chat_id");
+    if (storedChatId) {
+      this.chatId = storedChatId;
+    }
+  },
+
   watch: {
     externalShowForm(newVal) {
       this.showForm = newVal;
     },
   },
+
   methods: {
     openPatientForm() {
       this.showForm = true;
@@ -92,6 +103,15 @@ export default {
       this.showForm = false;
       this.$emit("update:externalShowForm", false);
     },
+
+    // (Valinnainen) Aloita uusi keskustelu
+    newChat() {
+      this.chatId = null;
+      localStorage.removeItem("chat_id");
+      this.messages = [];
+      this.welcomeMessageDisplayed = true;
+    },
+
     async fetchMapping() {
       try {
         const response = await axios.get("http://127.0.0.1:8000/api/data");
@@ -100,16 +120,28 @@ export default {
         console.error(this.$t("data-error"), error);
       }
     },
+
     async sendMessage() {
       if (this.newMessage.trim() === "") return;
 
       // Lisää käyttäjän viesti chattiin
-      this.messages.push({ text: this.newMessage, from: "self" });
+      const userText = this.newMessage;
+      this.messages.push({ text: userText, from: "self" });
+
+      // Tyhjennä syötekenttä heti (UI tuntuu nopeammalta)
+      this.newMessage = "";
 
       try {
         const response = await axios.post("http://127.0.0.1:8000/api/send", {
-          message: this.newMessage,
+          message: userText,
+          chat_id: this.chatId, // lähetetään sama chat_id jokaisella viestillä
         });
+
+        // Tallenna chat_id, jotta seuraavat viestit menevät samaan keskusteluun
+        if (response.data.chat_id) {
+          this.chatId = response.data.chat_id;
+          localStorage.setItem("chat_id", this.chatId);
+        }
 
         // Lisää palvelimen vastaus chattiin
         this.messages.push({ text: response.data.reply, from: "other" });
@@ -117,9 +149,6 @@ export default {
         console.error(this.$t("send-error"), error);
         this.messages.push({ text: this.$t("connection-error"), from: "other" });
       }
-
-      // Tyhjennä syötekenttä
-      this.newMessage = "";
     },
   },
 };


### PR DESCRIPTION
- removes the global in-memory chat history and replaces it with MongoDB-based persistence per user_id + chat_id
- New database layer for chat messages: chat_store.py
- Aligned sender roles with professional model:  "user" ,"bot", "professional" (tried to align with Timi's roles)
- Chat.vue now sends and preserves chat_id across requests.