### PR TITLE
Add unclaim endpoint and migrate backend to PyMongo Async API

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,7 +10,7 @@ langchain-core==1.2.11
 
 #setup
 python-dotenv==1.1.0
-motor==3.7.1
+pymongo==4.16.0
 fastapi==0.115.0
 httpx==0.28.1
 flask==3.1.1

--- a/backend/src/database/db.py
+++ b/backend/src/database/db.py
@@ -1,22 +1,7 @@
 import os
-import asyncio
 from dotenv import load_dotenv
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 import logging
-
-"""
-!! HUOM !!
-
-As of May 14, 2025, Motor is deprecated in favor of the GA release of the PyMongo
-Async API in the PyMongo library. We will not add new features to Motor, and we
-will provide only bug fixes until it reaches end of life on May 14, 2026. After
-that, we will fix only critical bugs until final support ends on May 14, 2027.
-We strongly recommend migrating to the PyMongo Async API while Motor is still
-supported.
-
-For more information about migrating, see the Migrate to PyMongo Async guide in
-the PyMongo documentation.
-"""
 
 # Handles MongoDB connection
 
@@ -51,7 +36,7 @@ messages_collection = None
 
 # Connect to MongoDB
 try:
-    client = AsyncIOMotorClient(MONGO_URI)
+    client = AsyncMongoClient(MONGO_URI)
     db = client["chatbot_database"] 
     users_collection = db["users"]
     

--- a/backend/src/routes/professional.py
+++ b/backend/src/routes/professional.py
@@ -7,12 +7,14 @@ These endpoints allow professionals to manage patient chat sessions:
 - Claim a waiting chat to begin handling it
 - Send messages to patients
 - Close resolved chats
+- Unclaim assigned chats
 
 Endpoints:
     GET  /professional/chats/queue
     GET  /professional/chats/{chat_id}
     POST /professional/chats/{chat_id}/close
     POST /professional/chats/{chat_id}/claim
+    POST /professional/chats/{chat_id}/unclaim
     POST /professional/chats/{chat_id}/messages
 """
 
@@ -168,7 +170,55 @@ async def claim_chat(id: str, current_user: Dict[str, Any] = Depends(get_current
 
 
 # -----------------------------
-# 5. POST /chats/{id}/messages
+# 5. POST /chats/{id}/unclaim
+# -----------------------------
+@router.post("/chats/{id}/unclaim", response_model=StatusResponse)
+async def unclaim_chat(id: str, current_user: Dict[str, Any] = Depends(get_current_user)):
+    """
+    A professional releases a claimed chat, making it available for others.
+    Transitions chat status from IN_PROGRESS to WAITING and unassigns the professional.
+
+    Only users with the "professional" role can unclaim chats.
+    """
+    if current_user.get("role") != "professional":
+        raise HTTPException(status_code=403, detail="Only professionals can unclaim chats")
+
+    professional_id = current_user["_id"]  
+
+    # Validate both IDs before querying the database
+    if not ObjectId.is_valid(id) or not ObjectId.is_valid(professional_id):
+        raise HTTPException(400, "Invalid ObjectId format")
+
+    # Fetch chat to check ownership
+
+    chat = await chats_collection.find_one({"_id": ObjectId(id)})
+    if not chat:
+        raise HTTPException(404, "Chat not found")
+
+    if chat.get("assigned_professional_id") != ObjectId(professional_id):
+        raise HTTPException(403, "You can only unclaim chats assigned to you")
+
+    if chat.get("status") != ChatStatus.IN_PROGRESS:
+        raise HTTPException(400, "Only chats in progress can be unclaimed")
+
+    # Update chat status to WAITING and remove assignment
+    result = await chats_collection.update_one(
+        {"_id": ObjectId(id)},
+        {"$set": {
+            "status": ChatStatus.WAITING,
+            "assigned_professional_id": None,
+            "updated_at": datetime.utcnow()
+        }}
+    )
+
+    if result.matched_count == 0:
+        raise HTTPException(404, "Chat not found")
+
+    return {"status": "success", "message": "Chat unclaimed successfully"}
+
+
+# -----------------------------
+# 6. POST /chats/{id}/messages
 # -----------------------------
 @router.post("/chats/{id}/messages", response_model=MessageDetailResponse)
 async def send_professional_message(id: str, body: ProfessionalMessageRequest, current_user: Dict[str, Any] = Depends(get_current_user)):

--- a/backend/src/utils/chat_utils.py
+++ b/backend/src/utils/chat_utils.py
@@ -7,7 +7,7 @@ async def get_chat_summaries(filter_query: dict):
     ObjectIds are converted to strings directly in the database query,
     so no manual iteration is needed after fetching.
     """
-    return await chats_collection.aggregate([
+    cursor = await chats_collection.aggregate([
         {"$match": filter_query},
         {
             "$project": {
@@ -18,7 +18,9 @@ async def get_chat_summaries(filter_query: dict):
                 "_id": 0,
             }
         }
-    ]).to_list(None)
+    ])
+
+    return await cursor.to_list(None)
 
 
 async def get_chats_with_messages(filter_query: dict):
@@ -67,4 +69,6 @@ async def get_chats_with_messages(filter_query: dict):
         {"$sort": {"updated_at": -1}}
     ]
 
-    return await chats_collection.aggregate(pipeline).to_list(None)
+    cursor = await chats_collection.aggregate(pipeline)
+
+    return await cursor.to_list(None)

--- a/frontend/src/services/professionalChatService.js
+++ b/frontend/src/services/professionalChatService.js
@@ -15,6 +15,11 @@ export const claim = async (chatId) => {
     return response.data
 }
 
+export const unclaim = async (chatId) => {
+  const response = await api.post(`/api/professional/chats/${chatId}/unclaim`)
+  return response.data
+}
+
 export const close = async (chatId) => {
     const response = await api.post(`/api/professional/chats/${chatId}/close`)
     return response.data

--- a/frontend/src/stores/professionalChatStore.js
+++ b/frontend/src/stores/professionalChatStore.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia"
-import { addProfessionalMessage, close, claim, fetchQueues } from "@/services/professionalChatService"
+import { addProfessionalMessage, close, claim, fetchQueues, unclaim } from "@/services/professionalChatService"
 import { useAuthStore } from "@/stores/authStore"
 
 export const useProfessionalChatStore = defineStore("professionalChat", {
@@ -53,7 +53,7 @@ export const useProfessionalChatStore = defineStore("professionalChat", {
         return
       }
 
-      if (chat.status !== "waiting") {
+      if (chat.status !== "waiting_for_professional") {
         console.log("Chat is not in waiting state")
         return
       }
@@ -68,6 +68,33 @@ export const useProfessionalChatStore = defineStore("professionalChat", {
 
       } catch(error) {
         console.error("Failed to claim the chat:", error)
+      }
+    },
+    async unclaimChat() {
+      const chat = this.getActiveChat
+      if (!chat) return
+
+      const authStore = useAuthStore()
+
+      if (chat.status !== "in_progress") {
+        console.log("Chat is not in progress")
+        return
+      }
+
+      if (chat.assigned_professional_id !== authStore.getCurrentUserID) {
+        console.log("You are not assigned to this chat")
+        return
+      }
+
+      try {
+        await unclaim(chat.id)
+
+        chat.status = "waiting_for_professional"
+        chat.assigned_professional_id = null
+
+        this.moveChatBetweenQueues(chat, "in_progress", "waiting")
+      } catch (error) {
+        console.error("Failed to unclaim the chat:", error)
       }
     },
     async closeChat() {


### PR DESCRIPTION
This pull request adds the ability for professionals to unclaim a chat they previously claimed and updates the backend to use the PyMongo Async API instead of Motor.

Changes include:

- Backend: 
  - Added POST /chats/{id}/unclaim endpoint 
    - Professionals can release a chat, changing its status from in_progress → waiting_for_professional
    - Only the professional assigned to the chat can unclaim it
  - Migrated MongoDB operations from Motor to PyMongo Async API across the backend
- Frontend: 
  - Added unclaimChat action in professionalChatStore
    - Updates the local queues when a chat is unclaimed
    - Ensures only the assigned professional can unclaim