### PR TITLE
cache logic for summarizer to avoid unnecessary LLM calls.

### DIFF
--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 # LLM tiivistämiseen (matala temperature tarkkuuden vuoksi)
 summarizer_llm = ChatGoogleGenerativeAI(
     model='gemini-2.0-flash-001',
-    temperature=0.3,
+    temperature=0,
     max_tokens=800,
     google_api_key=settings.GOOGLE_API_KEY
 )

--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -109,9 +109,9 @@ async def generate_summary_for_professional(
     draft_response = ""
     last_human_msg = ""
     for msg in reversed(messages):
-        msg_type = getattr(msg, "type", None) or msg.get("type")
-        if msg_type == "human":
-            last_human_msg = getattr(msg, "content", None) or msg.get("content", "")
+        sender = msg.get("sender") or msg.get("type", "")
+        if sender in ("user", "human"):
+            last_human_msg = msg.get("content", "")
             break
 
     if last_human_msg:

--- a/backend/src/routes/professional.py
+++ b/backend/src/routes/professional.py
@@ -97,10 +97,60 @@ async def get_chat(id: str):
     # Generate summary only for chats awaiting or in professional review
     summary_data = {}
     if chat.get("status") in (ChatStatus.WAITING, ChatStatus.IN_PROGRESS):
-        summary_data = await generate_summary_for_professional(
-            messages=chat.get("messages", []),
-            user_data=user_data,
-        )
+        messages = chat.get("messages", [])
+        current_msg_count = len(messages)
+        cached = chat.get("summary_cache")
+        has_professional = bool(chat.get("assigned_professional_id"))
+
+        if has_professional:
+            # IN_PROGRESS: permanent cache — never regenerate
+            if cached:
+                summary_data = {
+                    "chat_summary": cached.get("chat_summary"),
+                    "draft_response": cached.get("draft_response"),
+                    "requires_approval": True,
+                }
+            else:
+                # Edge case: claimed but no cache (e.g. legacy data)
+                summary_data = await generate_summary_for_professional(
+                    messages=messages,
+                    user_data=user_data,
+                )
+                await chats_collection.update_one(
+                    {"_id": ObjectId(id)},
+                    {"$set": {
+                        "summary_cache": {
+                            "chat_summary": summary_data["chat_summary"],
+                            "draft_response": summary_data["draft_response"],
+                            "cached_at": datetime.utcnow(),
+                        }
+                    }}
+                )
+        else:
+            # WAITING: message_count-based cache
+            if (cached and current_msg_count > 0
+                    and cached.get("message_count") == current_msg_count):
+                summary_data = {
+                    "chat_summary": cached.get("chat_summary"),
+                    "draft_response": cached.get("draft_response"),
+                    "requires_approval": True,
+                }
+            else:
+                summary_data = await generate_summary_for_professional(
+                    messages=messages,
+                    user_data=user_data,
+                )
+                await chats_collection.update_one(
+                    {"_id": ObjectId(id)},
+                    {"$set": {
+                        "summary_cache": {
+                            "chat_summary": summary_data["chat_summary"],
+                            "draft_response": summary_data["draft_response"],
+                            "message_count": current_msg_count,
+                            "cached_at": datetime.utcnow(),
+                        }
+                    }}
+                )
 
     summary_data["patient_context"] = user_data["patient_info"] if user_data and "patient_info" in user_data else "No patient data available."
     return ChatDetailResponse(**chat, **summary_data)
@@ -202,14 +252,17 @@ async def unclaim_chat(id: str, current_user: Dict[str, Any] = Depends(get_curre
     if chat.get("status") != ChatStatus.IN_PROGRESS:
         raise HTTPException(400, "Only chats in progress can be unclaimed")
 
-    # Update chat status to WAITING and remove assignment
+    # Update chat status to WAITING, remove assignment, and clear cache
     result = await chats_collection.update_one(
         {"_id": ObjectId(id)},
-        {"$set": {
-            "status": ChatStatus.WAITING,
-            "assigned_professional_id": None,
-            "updated_at": datetime.utcnow()
-        }}
+        {
+            "$set": {
+                "status": ChatStatus.WAITING,
+                "assigned_professional_id": None,
+                "updated_at": datetime.utcnow()
+            },
+            "$unset": {"summary_cache": ""}
+        }
     )
 
     if result.matched_count == 0:

--- a/backend/src/routes/professional.py
+++ b/backend/src/routes/professional.py
@@ -103,15 +103,23 @@ async def get_chat(id: str):
         has_professional = bool(chat.get("assigned_professional_id"))
 
         if has_professional:
-            # IN_PROGRESS: permanent cache — never regenerate
-            if cached:
+            # IN_PROGRESS: check message_count once, then freeze permanently
+            cached_count = cached.get("message_count") if cached else None
+            if cached and (cached_count is None or cached_count == current_msg_count):
+                # Frozen cache OR fresh WAITING-cache → use as-is
+                if cached_count is not None:
+                    # Still has message_count → freeze it now
+                    await chats_collection.update_one(
+                        {"_id": ObjectId(id)},
+                        {"$unset": {"summary_cache.message_count": ""}}
+                    )
                 summary_data = {
                     "chat_summary": cached.get("chat_summary"),
                     "draft_response": cached.get("draft_response"),
                     "requires_approval": True,
                 }
             else:
-                # Edge case: claimed but no cache (e.g. legacy data)
+                # No cache or stale cache → regenerate and freeze (no message_count)
                 summary_data = await generate_summary_for_professional(
                     messages=messages,
                     user_data=user_data,


### PR DESCRIPTION
- Avaa chatin ekan kerran (GET /professional/chats/{id}) → kutsutaan LLM ja tallennetaan summary ja draft_response mongoon summary_cacheen. Toteutettu message_countilla, kun se muuttuu, cache invalidoidaan.                                              
- Avaa sama chat uudelleen → vastaus tulee cachesta, ei LLM-kutsua.                                                                                                                                                                                          
- Lähetä uusi viesti WAITING-chattiin, avaa se sitten → cache vanhenee, koska message_count eri, uusi LLM-kutsu ja tallennus cacheen.                                                                                                                                                 
- Claim chat → status muuttuu IN_PROGRESS:ksi. Seuraava avaus käyttää olemassa olevaa WAITING-cacheä pysyvänä, ei uutta LLM-kutsua, paitsi jos tässä välissä tullut uusi viesti luodaan uusi summary. Jos cachea ei vielä ole (chat claimataan ennen kuin kukaan on avannut sitä), ensimmäinen avaus kutsuu LLM:ää ja luo pysyvän cachen.
- Unclaim chat → summary_cache poistetaan, seuraava avaus generoi molemmat kentät uudelleen.