### PR TITLE
Prevent non-RAG answers by filtering chat history and disabling histo…

### DIFF
--- a/backend/src/ai_model/classifier.py
+++ b/backend/src/ai_model/classifier.py
@@ -33,7 +33,7 @@ class ClassificationResult:
 
 # Deterministic LLM for classification (temperature=0)
 classifier_llm = ChatGoogleGenerativeAI(
-    model='gemini-2.0-flash-001',
+    model='gemini-2.5-flash-lite',
     temperature=0.0,
     max_tokens=300,
     google_api_key=settings.GOOGLE_API_KEY

--- a/backend/src/ai_model/rag_cloud.py
+++ b/backend/src/ai_model/rag_cloud.py
@@ -22,7 +22,7 @@ vectorstore = initialize_vectorstore(
 # -----------------------------
 
 llm = ChatGoogleGenerativeAI(
-    model='gemini-2.0-flash-001',  # Gemini 2.0 Flash
+    model='gemini-2.5-flash-lite',  # Gemini 2.0 Flash
     temperature=0.3,  # Alustava lämpötila
     max_tokens=1000,  # nostettu 500 -> 1000
     top_p=0.9,
@@ -62,6 +62,31 @@ prompt = ChatPromptTemplate.from_messages(
 )
 
 rag_chain = prompt | llm
+
+
+ALLOWED_HISTORY_CLASSIFICATIONS = {"safe", "needs_review", "emergency"}
+
+
+def _filter_chat_history(chat_history: list[dict] | None):
+    """
+    Suodattaa mallille välitettävän historian vain tunnetusti luokiteltuihin
+    viesteihin. Tämä vähentää testailun tai muun epäolennaisen historian
+    vaikutusta RAG-vastaukseen.
+    """
+    filtered_history = []
+
+    for message in chat_history or []:
+        classification = message.get("classification")
+        if classification is None:
+            continue
+
+        classification_value = str(classification).lower()
+        if classification_value not in ALLOWED_HISTORY_CLASSIFICATIONS:
+            continue
+
+        filtered_history.append(message)
+
+    return filtered_history
 
 
 def _normalize_chat_history(chat_history: list[dict] | None):
@@ -161,27 +186,23 @@ async def get_rag_response(
     Kysyy RAG-ketjulta (Chroma+GEMINI) ja palauttaa vastauksen sekä lähteet.
     Vastauksen muodostamiseen käytetään annettua chat-historiaa.
     """
-    history_messages = _normalize_chat_history(chat_history)
+    filtered_history = _filter_chat_history(chat_history)
+    history_messages = _normalize_chat_history(filtered_history)
 
     # Hae dokumentit threshold + fallback -logiikalla
     relevant_docs = await retrieve_with_fallback(user_input, vectorstore)
 
     if not relevant_docs:
-        # Jos historiaa on, annetaan mallin vastata historian perusteella ilman dokumenttikontekstia
-        if history_messages:
-            context_text = ""
-            sources = []
-        else:
-            no_info_msg = (
-                "Valitettavasti minulla ei ole riittävästi tietoa kysymääsi aiheeseen. "
-                "Suosittelen ottamaan yhteyttä asiantuntijaan tai hoitavaan tahoon."
-            )
-            return {
-                "answer": no_info_msg,
-                "sources": []
-            }
-    else:
-        context_text, sources = _build_context_and_sources(relevant_docs)
+        no_info_msg = (
+            "Valitettavasti minulla ei ole riittävästi tietoa kysymääsi aiheeseen. "
+            "Suosittelen ottamaan yhteyttä asiantuntijaan tai hoitavaan tahoon."
+        )
+        return {
+            "answer": no_info_msg,
+            "sources": []
+        }
+
+    context_text, sources = _build_context_and_sources(relevant_docs)
 
     # Vastauksen generointi
     response = await rag_chain.ainvoke({

--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # LLM tiivistämiseen (matala temperature tarkkuuden vuoksi)
 summarizer_llm = ChatGoogleGenerativeAI(
-    model='gemini-2.0-flash-001',
+    model='gemini-2.5-flash-lite',
     temperature=0,
     max_tokens=800,
     google_api_key=settings.GOOGLE_API_KEY

--- a/backend/src/routes/chat.py
+++ b/backend/src/routes/chat.py
@@ -98,7 +98,11 @@ async def send_message_to_chat(
     existing_messages = await get_chat_messages(chatId)
 
     conversation_history = [
-        {"sender": message["sender"], "content": message["content"]}
+        {
+            "sender": message["sender"],
+            "content": message["content"],
+            "classification": message.get("classification"),
+        }
         for message in existing_messages
     ]
 


### PR DESCRIPTION
- Updated LLM to Gemini-2.5-flash-lite
- Hardened the RAG response flow to prevent answers without retrieved source support
- Removed the history-only fallback path when no relevant documents are found
- Added classification to conversation history passed from chat.py to the RAG layer
- Filtered chat history before sending it to the model so only known classified messages are included

-> The chatbot no longer generates normal responses based only on prior chat history when retrieval fails
-> Out-of-scope questions are more reliably answered with the intended fallback message