### PR TITLE
Fix stale professional waiting banner after logout

### DIFF
--- a/frontend/src/components/chat/Chat.vue
+++ b/frontend/src/components/chat/Chat.vue
@@ -198,6 +198,18 @@ export default {
     const waitingForProfessional = ref(false)
     const showForm = ref(false)
 
+    const syncWaitingIndicators = (chat) => {
+      if (!authStore.isAuthenticated || !chat) {
+        waitingForBot.value = false
+        waitingForProfessional.value = false
+        return
+      }
+
+      if (!["waiting_for_professional", "in_progress"].includes(chat.status)) {
+        waitingForProfessional.value = false
+      }
+    }
+
     const scrollToBottom = () => {
       nextTick(() => {
         if (messagesEl.value) {
@@ -232,6 +244,7 @@ export default {
 
     onMounted(() => {
       chatStore.resetTransientState()
+      syncWaitingIndicators(chatStore.activeChat)
 
       if (chatStore.activeChat) {
         connectWebsocket(chatStore.activeChat)
@@ -244,9 +257,11 @@ export default {
       () => chatStore.activeChat,
       (newChat) => {
         if (!newChat) {
+          syncWaitingIndicators(null)
           welcomeMessageDisplayed.value = true
           return
         }
+        syncWaitingIndicators(newChat)
         connectWebsocket(newChat)
         welcomeMessageDisplayed.value = !newChat.messages?.length
         scrollToBottom()
@@ -261,6 +276,24 @@ export default {
         scrollToBottom()
       },
       { deep: true },
+    )
+
+    watch(
+      () => chatStore.activeChat?.status,
+      () => {
+        syncWaitingIndicators(chatStore.activeChat)
+      },
+      { immediate: true },
+    )
+
+    watch(
+      () => authStore.isAuthenticated,
+      (isAuthenticated) => {
+        if (!isAuthenticated) {
+          syncWaitingIndicators(null)
+        }
+      },
+      { immediate: true },
     )
 
     watch(

--- a/frontend/src/stores/userChatStore.js
+++ b/frontend/src/stores/userChatStore.js
@@ -30,6 +30,7 @@ export const useUserChatStore = defineStore("userChat", {
       this.isLoaded = false // Resetoi lataustilan
       this.isSending = false
       this.isLoadingChat = false
+      this.pendingConfirmationMessageId = null
       if (sessionStorage.getItem("userChat")) {
         sessionStorage.removeItem("userChat")
       }
@@ -37,6 +38,7 @@ export const useUserChatStore = defineStore("userChat", {
     resetTransientState() {
       this.isSending = false
       this.isLoadingChat = false
+      this.pendingConfirmationMessageId = null
     },
     // Chatien haku ja alustaminen
     async initializeChats(force = false) {


### PR DESCRIPTION
Reset professional waiting UI state on logout and chat changes to prevent stale banner from persisting on the main view