### PR TITLE
Feature/summary titles

### DIFF
--- a/backend/src/ai_model/emergency.py
+++ b/backend/src/ai_model/emergency.py
@@ -130,7 +130,6 @@ EMERGENCY_PATTERNS_FI = [
 
 EMERGENCY_PATTERNS_EN = [
     re.compile(r"\bheart\s+attack\w*\b", re.IGNORECASE),
-    re.compile(r"\bchest\s+pain\w*\b", re.IGNORECASE),
     re.compile(r"\bstroke\b", re.IGNORECASE),
     re.compile(r"\bcan'?t\s+breathe\b", re.IGNORECASE),
     re.compile(r"\bunconscious\w*\b", re.IGNORECASE),

--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -137,3 +137,27 @@ async def generate_summary_for_professional(
         "draft_response": draft_response,
         "requires_approval": True,
     }
+
+
+CHAT_TITLE_PROMPT = """Generate an extremely concise title (3-6 words) for a health chat conversation.
+Detect the language of the message (Finnish or English) and write the title in the SAME language.
+Do NOT use quotes, punctuation marks, or any surrounding text — output ONLY the title words.
+
+User's first message: {message}
+
+Title:"""
+
+
+async def generate_chat_title(first_message: str) -> str | None:
+    """
+    Generates a short 3-6 word title for a chat based on the user's first message.
+    Returns None on failure. Never raises.
+    """
+    try:
+        prompt = CHAT_TITLE_PROMPT.format(message=first_message[:400])
+        response = await summarizer_llm.ainvoke(prompt)
+        title = response.content.strip().strip('"\'')
+        return title[:80] if title else None
+    except Exception as e:
+        logger.error(f"Chat title generation failed: {e}")
+        return None

--- a/backend/src/database/models.py
+++ b/backend/src/database/models.py
@@ -145,6 +145,7 @@ class ChatSummaryItem(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+    title: Optional[str] = None
 
 # Professional
 class MessageDetailResponse(BaseModel):
@@ -178,6 +179,7 @@ class ChatDetailResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     messages: List[MessageDetailResponse]
+    title: Optional[str] = None
     # Summarizer fields — only populated in GET /chats/{id}, None in queue view
     patient_context: Optional[PatientInfo] = None
     chat_summary: Optional[str] = None

--- a/backend/src/routes/chat.py
+++ b/backend/src/routes/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -7,7 +8,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from ai_model.summarizer import generate_summary_for_professional
+from ai_model.summarizer import generate_summary_for_professional, generate_chat_title
 from ai_model import rag_cloud, utils
 from ai_model.classifier import classify_question, Classification as AiClassification
 from ai_model.emergency import detect_emergency
@@ -27,6 +28,7 @@ from utils.chat_utils import (
     get_chat_summaries,
     get_chats_with_messages,
     save_chat_message,
+    set_chat_title,
     touch_chat,
 )
 from src.websocket_manager import manager
@@ -34,6 +36,17 @@ from src.websocket_manager import manager
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def _generate_and_save_title(chat_id: str, first_message: str) -> None:
+    """Fire-and-forget: generates and persists a chat title. Errors are swallowed."""
+    try:
+        title = await generate_chat_title(first_message)
+        if title:
+            await set_chat_title(chat_id, title)
+            logger.info("Chat title saved for %s: %r", chat_id, title)
+    except Exception as e:
+        logger.error("Title generation task failed for chat %s: %s", chat_id, e)
 
 
 async def _get_owned_chat_or_404(chat_id: str, current_user: Dict[str, Any]) -> dict:
@@ -106,6 +119,8 @@ async def send_message_to_chat(
     professional_id = chat.get("assigned_professional_id")
     chat_status = chat.get("status")
     messages = chat.get("messages", [])
+    existing_title = chat.get("title")
+    is_first_message = len(messages) == 0
 
     conversation_history = [
         {
@@ -119,6 +134,10 @@ async def send_message_to_chat(
     user_message = body.message
     user_data = current_user
     logged_in = True
+
+    # Fire-and-forget: generate title after first complete exchange
+    if is_first_message and not existing_title:
+        asyncio.create_task(_generate_and_save_title(chatId, user_message))
 
     # Lähetetään viesti suoraan ammattilaiselle websocketin välityksellä, jos
     # viestittely-yhteys ammattilaisen ja potilaan välillä on avoin -> ei tarvitse muodostaa

--- a/backend/src/routes/chat.py
+++ b/backend/src/routes/chat.py
@@ -360,3 +360,17 @@ async def update_chat_status(
 ):
     await _get_owned_chat_or_404(chatId, current_user)
     await touch_chat(chatId, status=body.status)
+
+
+class ChatTitleUpdate(BaseModel):
+    title: str
+
+
+@router.put("/{chatId}/title", status_code=204)
+async def update_chat_title(
+    chatId: str,
+    body: ChatTitleUpdate,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    await _get_owned_chat_or_404(chatId, current_user)
+    await set_chat_title(chatId, body.title.strip()[:80])

--- a/backend/src/utils/chat_utils.py
+++ b/backend/src/utils/chat_utils.py
@@ -132,6 +132,7 @@ async def get_chat_summaries(filter_query: dict):
                 "status": 1,
                 "created_at": 1,
                 "updated_at": 1,
+                "title": 1,
                 "_id": 0,
             }
         },
@@ -246,6 +247,18 @@ async def save_chat_message(
 
     normalized = _normalize_message_doc(new_message)
     return MessageDetailResponse(**normalized)
+
+
+async def set_chat_title(chat_id: str | ObjectId, title: str) -> None:
+    """
+    Persists an AI-generated title to the chat document.
+    Does not touch updated_at so sidebar sort order is unaffected.
+    """
+    chat_object_id = ObjectId(chat_id) if isinstance(chat_id, str) else chat_id
+    await chats_collection.update_one(
+        {"_id": chat_object_id},
+        {"$set": {"title": title}},
+    )
 
 
 async def touch_chat(chat_id: str | ObjectId, *, status=None) -> None:

--- a/backend/tests/test_emergency.py
+++ b/backend/tests/test_emergency.py
@@ -281,7 +281,7 @@ class TestCaseInsensitivity:
         assert result is not None
 
     def test_mixed_case_english(self):
-        result = detect_emergency("Heart Attack symptoms now")
+        result = detect_emergency("I Am Having A Heart Attack")
         assert result is not None
 
     def test_uppercase_finnish(self):

--- a/backend/tests/test_emergency.py
+++ b/backend/tests/test_emergency.py
@@ -20,11 +20,6 @@ class TestEnglishKeywords:
         assert result is not None
         assert any("heart attack" in kw for kw in result.matched_keywords)
 
-    def test_chest_pain(self):
-        result = detect_emergency("I have severe chest pain")
-        assert result is not None
-        assert any("chest pain" in kw for kw in result.matched_keywords)
-
     def test_stroke(self):
         result = detect_emergency("I think my dad is having a stroke")
         assert result is not None
@@ -286,7 +281,7 @@ class TestCaseInsensitivity:
         assert result is not None
 
     def test_mixed_case_english(self):
-        result = detect_emergency("Chest Pain is severe")
+        result = detect_emergency("Heart Attack symptoms now")
         assert result is not None
 
     def test_uppercase_finnish(self):

--- a/frontend/src/components/ChatHistorySidebar.vue
+++ b/frontend/src/components/ChatHistorySidebar.vue
@@ -17,12 +17,36 @@
             v-for="chat in groupedChats"
             :key="chat.id"
             class="chat-item"
-            :class="{ 'active-chat': chat.id === activeChatId }"
-            @click="selectChatAndClose(chat)"
+            :class="{ 'active-chat': chat.id === activeChatId, 'editing': editingChatId === chat.id }"
+            @click="editingChatId !== chat.id && selectChatAndClose(chat)"
           >
-            <span class="chat-title" :title="chat.lastMessage">
-              {{ chat.lastMessage || $t('sidebar.defaultTitle') }}
-            </span>
+            <div class="chat-title-row">
+              <span v-if="editingChatId !== chat.id" class="chat-title" :title="chat.lastMessage">
+                {{ chat.lastMessage || $t('sidebar.defaultTitle') }}
+              </span>
+              <input
+                v-else
+                ref="titleInputRef"
+                class="chat-title-input"
+                v-model="editingTitle"
+                :placeholder="$t('sidebar.titlePlaceholder')"
+                @keydown.enter.prevent="saveTitle(chat.id)"
+                @keydown.escape.prevent="cancelEdit"
+                @blur="saveTitle(chat.id)"
+                @click.stop
+              />
+              <button
+                v-if="editingChatId !== chat.id"
+                class="edit-title-btn"
+                :title="$t('sidebar.editTitle')"
+                @click.stop="startEdit(chat, $event)"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                </svg>
+              </button>
+            </div>
             <span class="chat-date">
               {{ formatDate(chat.lastMessageDate) }}
             </span>
@@ -42,7 +66,8 @@
 </template>
 
 <script>
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick } from 'vue'
+import { useUserChatStore } from '@/stores/userChatStore'
 
 export default {
   name: 'ChatHistorySidebar',
@@ -81,6 +106,13 @@ export default {
     return {
       chatsContainer,
       scrollToTop
+    }
+  },
+
+  data() {
+    return {
+      editingChatId: null,
+      editingTitle: '',
     }
   },
 
@@ -128,6 +160,29 @@ export default {
 
     closeSidebar() {
       this.$emit('close-sidebar');
+    },
+
+    startEdit(chat, event) {
+      event.stopPropagation()
+      this.editingChatId = chat.id
+      this.editingTitle = chat.lastMessage
+      nextTick(() => {
+        const input = this.$refs.titleInputRef?.[0]
+        if (input) input.focus()
+      })
+    },
+
+    async saveTitle(chatId) {
+      const trimmed = this.editingTitle.trim()
+      if (trimmed) {
+        const chatStore = useUserChatStore()
+        await chatStore.updateChatTitle(chatId, trimmed)
+      }
+      this.editingChatId = null
+    },
+
+    cancelEdit() {
+      this.editingChatId = null
     },
 
     // Päivämäärän muotoilu (tänään, eilen, muuten pvm)
@@ -382,16 +437,64 @@ export default {
   background: #e5e7eb;
 }
 
+.chat-title-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+}
+
 .chat-title {
-  display: block;
+  flex: 1;
+  min-width: 0;
   font-size: 14px;
   font-weight: 500;
   color: #0f172a;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  word-break: break-word;
   line-height: 1.3;
+}
+
+.edit-title-btn {
+  flex-shrink: 0;
+  opacity: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 3px;
+  color: #94a3b8;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.chat-item:hover .edit-title-btn {
+  opacity: 1;
+}
+
+.edit-title-btn:hover {
+  color: #2563eb;
+}
+
+.chat-title-input {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: #0f172a;
+  border: 1px solid #2563eb;
+  border-radius: 4px;
+  padding: 1px 6px;
+  background: white;
+  outline: none;
+  line-height: 1.3;
+}
+
+.chat-item.editing {
+  cursor: default;
 }
 
 .chat-date {

--- a/frontend/src/components/ChatHistorySidebar.vue
+++ b/frontend/src/components/ChatHistorySidebar.vue
@@ -93,16 +93,17 @@ export default {
             (a, b) => new Date(b.created_at) - new Date(a.created_at)
             )
 
-            // Etsi viimeisin käyttäjän viesti
+            // Etsi viimeisin käyttäjän viesti (fallback jos AI-otsikkoa ei ole)
             const lastUserMsg = messages.find(m => m.sender === 'user')
-            const messageText = lastUserMsg?.content || messages[0]?.content || this.$t('sidebar.defaultTitle')
-            
+            const fallback = lastUserMsg?.content || messages[0]?.content || this.$t('sidebar.defaultTitle')
+            const displayTitle = chat.title || fallback
+
             // Käytä viimeisin viestin aikaa tai chatin updated_at
             const lastMessageDate = messages[0]?.created_at || chat.updated_at || chat.created_at
 
             return {
             id: chat.id,
-            lastMessage: messageText,
+            lastMessage: displayTitle,
             lastMessageDate: lastMessageDate,
             }
         })

--- a/frontend/src/components/chat/Chat.vue
+++ b/frontend/src/components/chat/Chat.vue
@@ -106,7 +106,7 @@
         :confirmation-answered="chatStore.pendingConfirmationMessageId !== message.id"
         :sources="message.sources || []"
         :extra-class="[
-          message.classification === 'needs_review' && !message.requires_confirmation ? 'needs-review' : '',
+          message.classification === 'needs_review' && !message.requires_confirmation && !message.guideline_excerpt ? 'needs-review' : '',
           message.classification === 'emergency' ? 'emergency' : '',
         ]"
         @confirm-helpful="chatStore.dismissConfirmation()"

--- a/frontend/src/components/chat/ChatMessage.vue
+++ b/frontend/src/components/chat/ChatMessage.vue
@@ -18,7 +18,7 @@
 
       <div class="bubble">
         <template v-if="requiresConfirmation || guidelineExcerpt">{{ $t('guidelineFound') }}</template>
-        <template v-else-if="requiresProfessional">{{ $t('forwardedToProfessional') }}</template>
+        <template v-else-if="requiresProfessional || (fromClass === 'other' && !text && !guidelineExcerpt && !isEmergency && !isForwardConfirmation)">{{ $t('forwardedToProfessional') }}</template>
         <template v-else-if="isForwardConfirmation">{{ $t('confirmForwarded') }}</template>
         <span v-else-if="isEmergency && fromClass === 'other'" v-html="$t('emergencyMessage')" />
         <span v-else v-html="text" />

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -251,7 +251,9 @@
     "defaultTitle": "New chat",
     "footer": "Chats are stored securely and are only visible to you",
     "delete": "Delete conversation",
-    "yesterdayAt": "Yesterday at"
+    "yesterdayAt": "Yesterday at",
+    "editTitle": "Rename",
+    "titlePlaceholder": "Chat title..."
   },
     "writeMessage": "Write a message",
     "lastMessage": "Last message",

--- a/frontend/src/locales/fi.json
+++ b/frontend/src/locales/fi.json
@@ -252,6 +252,8 @@
     "footer": "Keskustelut tallennetaan turvallisesti ja ovat vain sinun nähtävissä",
     "defaultTitle": "Uusi keskustelu",
     "delete": "Poista keskustelu",
-    "yesterdayAt": "Eilen klo"
+    "yesterdayAt": "Eilen klo",
+    "editTitle": "Nimeä uudelleen",
+    "titlePlaceholder": "Otsikko..."
   }
 }

--- a/frontend/src/services/userChatService.js
+++ b/frontend/src/services/userChatService.js
@@ -23,3 +23,6 @@ export const addChat = async () => {
 
 export const updateChatStatus = (chatId, status) =>
   api.put(`/api/chat/${chatId}/status`, { status })
+
+export const updateChatTitle = (chatId, title) =>
+  api.put(`/api/chat/${chatId}/title`, { title })

--- a/frontend/src/stores/userChatStore.js
+++ b/frontend/src/stores/userChatStore.js
@@ -6,6 +6,7 @@ import {
   sendUserMessage,
   fetchChat,
   updateChatStatus,
+  updateChatTitle,
 } from "@/services/userChatService"
 
 export const useUserChatStore = defineStore("userChat", {
@@ -338,6 +339,16 @@ export const useUserChatStore = defineStore("userChat", {
 
     dismissConfirmation() {
       this.pendingConfirmationMessageId = null
+    },
+    async updateChatTitle(chatId, title) {
+      await updateChatTitle(chatId, title)
+      const idx = this.userChats.findIndex(c => c.id === chatId)
+      if (idx !== -1) {
+        this.userChats[idx] = { ...this.userChats[idx], title }
+      }
+      if (this.activeChat?.id === chatId) {
+        this.activeChat = { ...this.activeChat, title }
+      }
     },
     async loadChatsWithMessages() {
       if (this.userChats.length === 0) return

--- a/frontend/src/stores/userChatStore.js
+++ b/frontend/src/stores/userChatStore.js
@@ -103,6 +103,7 @@ export const useUserChatStore = defineStore("userChat", {
         this.userChats.unshift({
           id: newChat.id,
           status: newChat.status,
+          title: newChat.title ?? null,
           created_at: newChat.created_at,
           updated_at: newChat.updated_at,
         })
@@ -130,6 +131,7 @@ export const useUserChatStore = defineStore("userChat", {
         this.userChats.unshift({
           id: newChat.id,
           status: newChat.status,
+          title: newChat.title ?? null,
           created_at: newChat.created_at,
           updated_at: newChat.updated_at,
         })
@@ -184,6 +186,9 @@ export const useUserChatStore = defineStore("userChat", {
           throw error
         }
       }
+
+      // Seurataan onko kyseessä ensimmäinen viesti (title-päivitystä varten)
+      const wasFirstMessage = chat.messages.length === 0
 
       // Näytetään käyttäjän viesti heti käyttöliittymässä ennen backend-vastausta
       const userMessage = {
@@ -290,6 +295,25 @@ export const useUserChatStore = defineStore("userChat", {
         throw error
       } finally {
         this.isSending = false
+      }
+
+      // Haetaan AI-generoitu title ensimmäisen viestin jälkeen viiveellä
+      if (wasFirstMessage) {
+        const chatIdForRefresh = chat.id
+        setTimeout(async () => {
+          try {
+            const updated = await fetchChat(chatIdForRefresh)
+            if (updated.title) {
+              const idx = this.userChats.findIndex(c => c.id === chatIdForRefresh)
+              if (idx !== -1) {
+                this.userChats[idx] = { ...this.userChats[idx], title: updated.title }
+              }
+              if (this.activeChat?.id === chatIdForRefresh) {
+                this.activeChat = { ...this.activeChat, title: updated.title }
+              }
+            }
+          } catch (e) { /* ignore */ }
+        }, 5000)
       }
     },
 

--- a/frontend/src/stores/userChatStore.js
+++ b/frontend/src/stores/userChatStore.js
@@ -73,21 +73,23 @@ export const useUserChatStore = defineStore("userChat", {
 
         // Jos chat odottaa ammattilaista ja sisältää käypähoidon ohjeen mutta ei
         // vahvistusviestiä, lisätään se synteettisesti (ei tallennu DB:hen).
-        // Ehto: guideline-viesti on viimeinen viesti jota ei seuraa käyttäjäviesti
-        // (eli käyttäjä klikkasi "Ei" eikä jatkanut kirjoittamista)
+        // Ehto: on olemassa guideline-viesti (käyttäjä kävi läpi Kyllä/Ei-valinnan)
         const hasForwardConfirmation = messages.some(m => m.is_forward_confirmation)
+        // Botti-viesti ilman guideline_excerpt näyttää automaattisesti "Tämä aihe liittyy..."
+        // → erillistä confirmation-viestiä ei tarvita
+        const hasDirectForwardMsg = messages.some(
+          m => m.sender === 'bot' && !m.content && !m.guideline_excerpt
+        )
         const guidelineMsgIdx = [...messages].map((m, i) => ({ m, i }))
           .filter(({ m }) => m.guideline_excerpt && m.sender === 'bot')
           .map(({ i }) => i)
-          .at(-1) // viimeisen guideline-viestin indeksi
+          .at(-1)
         const guidelineMsg = guidelineMsgIdx !== undefined ? messages[guidelineMsgIdx] : null
-        const noUserMsgAfterGuideline = guidelineMsg &&
-          !messages.slice(guidelineMsgIdx + 1).some(m => m.sender === 'user')
         if (
           chat.status === 'waiting_for_professional' &&
           guidelineMsg &&
-          noUserMsgAfterGuideline &&
-          !hasForwardConfirmation
+          !hasForwardConfirmation &&
+          !hasDirectForwardMsg
         ) {
           messages.push({
             id: 'forward-confirmation-' + chatId,

--- a/frontend/src/stores/userChatStore.js
+++ b/frontend/src/stores/userChatStore.js
@@ -69,10 +69,42 @@ export const useUserChatStore = defineStore("userChat", {
 
       try {
         const chat = await fetchChat(chatId)
+        const messages = chat.messages || []
+
+        // Jos chat odottaa ammattilaista ja sisältää käypähoidon ohjeen mutta ei
+        // vahvistusviestiä, lisätään se synteettisesti (ei tallennu DB:hen).
+        // Ehto: guideline-viesti on viimeinen viesti jota ei seuraa käyttäjäviesti
+        // (eli käyttäjä klikkasi "Ei" eikä jatkanut kirjoittamista)
+        const hasForwardConfirmation = messages.some(m => m.is_forward_confirmation)
+        const guidelineMsgIdx = [...messages].map((m, i) => ({ m, i }))
+          .filter(({ m }) => m.guideline_excerpt && m.sender === 'bot')
+          .map(({ i }) => i)
+          .at(-1) // viimeisen guideline-viestin indeksi
+        const guidelineMsg = guidelineMsgIdx !== undefined ? messages[guidelineMsgIdx] : null
+        const noUserMsgAfterGuideline = guidelineMsg &&
+          !messages.slice(guidelineMsgIdx + 1).some(m => m.sender === 'user')
+        if (
+          chat.status === 'waiting_for_professional' &&
+          guidelineMsg &&
+          noUserMsgAfterGuideline &&
+          !hasForwardConfirmation
+        ) {
+          messages.push({
+            id: 'forward-confirmation-' + chatId,
+            sender: 'bot',
+            content: '',
+            classification: 'needs_review',
+            is_forward_confirmation: true,
+            flagged_for_human: false,
+            sources: [],
+            created_at: guidelineMsg.created_at,
+            updated_at: guidelineMsg.updated_at,
+          })
+        }
 
         this.activeChat = {
           ...chat,
-          messages: chat.messages || [],
+          messages,
         }
       } catch (error) {
         console.error("Failed to load chat:", error)


### PR DESCRIPTION
- **AI-generoidut chat-otsikot** — ensimmäisen viestin perusteella generoidaan automaattisesti lyhyt otsikko chat-historian sivupalkkiin. Otsikko tallennetaan tietokantaan eikä vaikuta chatin `updated_at`-aikaleimaan.
- **Otsikon manuaalinen muokkaus** — sivupalkin chat-kohteessa näkyy kynäikoni hover-tilassa. Klikkaus avaa inline-tekstikentän; Enter/blur tallentaa, Escape peruuttaa.
- **Bugfix: "Välitetty ammattilaiselle" -viesti puuttui sivunlatauksella** — viesti rekonstruoidaan synteettisesti frontendin storessa, jos chat on `waiting_for_professional`-tilassa eikä vahvistusviestiä löydy DB:stä.
- **Bugfix: Hoitosuositusviesti muuttui keltaiseksi sivunlatauksella** — `needs-review` CSS-luokka ei enää sovelleta viestille, jolla on `guideline_excerpt`.
- **Poistettu rintakipu englanninkielisestä hätätilannistuksesta** — `chest pain` regex poistettiin `emergency.py`:stä, koska vastaavaa suomenkielistä tunnistusta ei ole.