### PR TITLE
Fix/language fix

### DIFF
--- a/backend/src/ai_model/rag_cloud.py
+++ b/backend/src/ai_model/rag_cloud.py
@@ -23,9 +23,9 @@ vectorstore = initialize_vectorstore(
 # -----------------------------
 
 llm = ChatGoogleGenerativeAI(
-    model='gemini-2.5-flash-lite',  # Gemini 2.0 Flash
-    temperature=0.3,  # Alustava lämpötila
-    max_tokens=1000,  # nostettu 500 -> 1000
+    model='gemini-2.5-flash-lite',  # Gemini 2.5 Flash Lite
+    temperature=0.3,
+    max_tokens=1000, 
     top_p=0.9,
     google_api_key=settings.GOOGLE_API_KEY
 )
@@ -33,7 +33,7 @@ llm = ChatGoogleGenerativeAI(
 selector_llm = ChatGoogleGenerativeAI(
     model='gemini-2.5-flash-lite',
     temperature=0.0,
-    max_tokens=5,           # Vain numero vastauksessa
+    max_tokens=5,
     google_api_key=settings.GOOGLE_API_KEY
 )
 
@@ -41,7 +41,7 @@ system_prompt = (
     "You are an assistant for question-answering tasks. "
     "Use the following pieces of retrieved context and chat history to answer the question. "
     "Do not use any outside knowledge or make assumptions. "
-    "Determine first whether the question is in Finnish or English, and respond in the same language. "
+    "{language_instruction} "
 
     "If the question is in English and the information is found in the context, first provide a concise answer. "
     "Then, naturally continue the conversation by asking a relevant follow-up question based on the user's query and chat history. "
@@ -73,6 +73,61 @@ rag_chain = prompt | llm
 
 
 ALLOWED_HISTORY_CLASSIFICATIONS = {"safe", "needs_review", "emergency"}
+
+
+def _infer_response_language(user_input: str) -> str:
+    """
+    Päättelee vastauskielen käyttäjän varsinaisesta viestistä.
+    Potilastiedot liitetään promptiin erillisenä englanninkielisenä osiona, joten
+    niitä ei saa käyttää vastauskielen päättelyyn.
+    """
+    question = (user_input or "").split("\n\nPatient info:", 1)[0].lower()
+    finnish_markers = (
+        "ä", "ö", "å", "minulla", "mulla", "olen", "onko", "voiko",
+        "pitääkö", "mitä", "mita", "kuinka", "miksi", "verenpaine",
+        "kolesteroli", "sydän", "sydan", "lääke", "laake", "oire",
+        "tarvitsen", "voinko", "pitäisikö", "pitäisiko", "arvo",
+        "arvot", "minun", "korkea", "matala",
+    )
+    english_markers = (
+        "what", "why", "how", "should", "can i", "could", " is ",
+        " are ", " my ", " i ", "blood pressure", "cholesterol",
+        "symptom", "medicine", "medication",
+    )
+    if any(marker in question for marker in finnish_markers):
+        return "fi"
+    if any(marker in question for marker in english_markers):
+        return "en"
+    return "unknown"
+
+
+def _language_instruction(language: str) -> str:
+    if language == "fi":
+        return (
+            "The user's actual question is in Finnish. Respond only in Finnish. "
+            "Ignore the language of metadata sections such as Patient info when choosing the response language."
+        )
+    if language == "unknown":
+        return (
+            "Determine whether the user's actual question is in Finnish or English, and respond in that same language. "
+            "Ignore the language of metadata sections such as Patient info when choosing the response language."
+        )
+    return (
+        "The user's actual question is in English. Respond only in English. "
+        "Ignore the language of metadata sections such as Patient info when choosing the response language."
+    )
+
+
+def _no_info_message(language: str) -> str:
+    if language != "en":
+        return (
+            "Valitettavasti minulla ei ole riittävästi tietoa kysymääsi aiheeseen. "
+            "Suosittelen ottamaan yhteyttä asiantuntijaan tai hoitavaan tahoon."
+        )
+    return (
+        "Unfortunately, I do not have enough information on the topic you asked about. "
+        "I recommend reaching out to a specialist or your healthcare provider if needed."
+    )
 
 
 def _filter_chat_history(chat_history: list[dict] | None):
@@ -420,17 +475,14 @@ async def get_rag_response(
     """
     filtered_history = _filter_chat_history(chat_history)
     history_messages = _normalize_chat_history(filtered_history)
+    response_language = _infer_response_language(user_input)
 
     # Hae dokumentit threshold + fallback -logiikalla
     relevant_docs = await retrieve_with_fallback(user_input, vectorstore)
 
     if not relevant_docs:
-        no_info_msg = (
-            "Valitettavasti minulla ei ole riittävästi tietoa kysymääsi aiheeseen. "
-            "Suosittelen ottamaan yhteyttä asiantuntijaan tai hoitavaan tahoon."
-        )
         return {
-            "answer": no_info_msg,
+            "answer": _no_info_message(response_language),
             "sources": []
         }
 
@@ -440,6 +492,7 @@ async def get_rag_response(
     response = await rag_chain.ainvoke({
         "context": context_text,
         "chat_history": history_messages,
+        "language_instruction": _language_instruction(response_language),
         "input": user_input
     })
 

--- a/backend/src/ai_model/rag_cloud.py
+++ b/backend/src/ai_model/rag_cloud.py
@@ -5,6 +5,7 @@ from .vectorstore import initialize_vectorstore
 from langchain_google_genai import GoogleGenerativeAIEmbeddings, ChatGoogleGenerativeAI
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import AIMessage, HumanMessage
+from langdetect import detect, LangDetectException
 
 # -----------------------------
 # 1) Upotukset ja vektorivarasto
@@ -81,23 +82,17 @@ def _infer_response_language(user_input: str) -> str:
     Potilastiedot liitetään promptiin erillisenä englanninkielisenä osiona, joten
     niitä ei saa käyttää vastauskielen päättelyyn.
     """
-    question = (user_input or "").split("\n\nPatient info:", 1)[0].lower()
-    finnish_markers = (
-        "ä", "ö", "å", "minulla", "mulla", "olen", "onko", "voiko",
-        "pitääkö", "mitä", "mita", "kuinka", "miksi", "verenpaine",
-        "kolesteroli", "sydän", "sydan", "lääke", "laake", "oire",
-        "tarvitsen", "voinko", "pitäisikö", "pitäisiko", "arvo",
-        "arvot", "minun", "korkea", "matala",
-    )
-    english_markers = (
-        "what", "why", "how", "should", "can i", "could", " is ",
-        " are ", " my ", " i ", "blood pressure", "cholesterol",
-        "symptom", "medicine", "medication",
-    )
-    if any(marker in question for marker in finnish_markers):
-        return "fi"
-    if any(marker in question for marker in english_markers):
-        return "en"
+    question = (user_input or "").split("\n\nPatient info:", 1)[0].strip()
+    if not question:
+        return "unknown"
+
+    try:
+        detected_language = detect(question)
+    except LangDetectException:
+        return "unknown"
+
+    if detected_language in ("fi", "en"):
+        return detected_language
     return "unknown"
 
 

--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -10,6 +10,7 @@ from config import settings
 import logging
 from typing import Optional
 from langchain_google_genai import ChatGoogleGenerativeAI
+from langdetect import detect, LangDetectException
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +59,16 @@ def _infer_conversation_language(messages: list, latest_message: str) -> str:
         if sender in ("user", "human"):
             patient_texts.append(msg.get("content", ""))
 
-    text = "\n".join([*patient_texts, latest_message]).lower()
-    finnish_markers = (
-        "ä", "ö", "å", "minulla", "mulla", "olen", "onko", "voiko",
-        "pitääkö", "mitä", "mita", "kuinka", "verenpaine", "kolesteroli",
-        "sydän", "sydan", "lääke", "laake", "oire", "tarvitsen",
-    )
-    return "fi" if any(marker in text for marker in finnish_markers) else "en"
+    text = "\n".join([*patient_texts, latest_message]).strip()
+    if not text:
+        return "en"
+
+    try:
+        detected_language = detect(text)
+    except LangDetectException:
+        return "en"
+
+    return "fi" if detected_language == "fi" else "en"
 
 
 def _draft_language_instruction(language: str) -> str:

--- a/backend/src/ai_model/summarizer.py
+++ b/backend/src/ai_model/summarizer.py
@@ -50,6 +50,29 @@ def _format_user_data(user_data: Optional[dict]) -> str:
     return "\n".join(parts) if parts else "No patient data available."
 
 
+def _infer_conversation_language(messages: list, latest_message: str) -> str:
+    """Päättelee keskustelukielen potilasviesteistä ammattilaisen draftia varten."""
+    patient_texts = []
+    for msg in messages:
+        sender = msg.get("sender") or msg.get("type", "")
+        if sender in ("user", "human"):
+            patient_texts.append(msg.get("content", ""))
+
+    text = "\n".join([*patient_texts, latest_message]).lower()
+    finnish_markers = (
+        "ä", "ö", "å", "minulla", "mulla", "olen", "onko", "voiko",
+        "pitääkö", "mitä", "mita", "kuinka", "verenpaine", "kolesteroli",
+        "sydän", "sydan", "lääke", "laake", "oire", "tarvitsen",
+    )
+    return "fi" if any(marker in text for marker in finnish_markers) else "en"
+
+
+def _draft_language_instruction(language: str) -> str:
+    if language == "fi":
+        return "Vastaa suomeksi. Säilytä sama kieli kuin potilaan keskustelussa."
+    return "Reply in English. Use the same language as the patient's conversation."
+
+
 PROFESSIONAL_SUMMARY_PROMPT = """You are a medical conversation summarizer. A patient has been chatting with a healthcare chatbot, and the system has flagged the conversation for professional review.
 
 Create a concise summary of the conversation for a healthcare professional to review.
@@ -116,14 +139,18 @@ async def generate_summary_for_professional(
             break
 
     if last_human_msg:
+        language_instruction = _draft_language_instruction(
+            _infer_conversation_language(messages, last_human_msg)
+        )
         if chat_summary:
             draft_prompt = (
+                f"{language_instruction}\n\n"
                 f"[Conversation summary: {chat_summary}]\n\n"
                 f"[Patient info: {patient_context}]\n\n"
                 f"Patient's latest message: {last_human_msg}"
             )
         else:
-            draft_prompt = last_human_msg
+            draft_prompt = f"{language_instruction}\n\n{last_human_msg}"
         try:
             from ai_model import rag_cloud, utils
             draft_result = await rag_cloud.get_rag_response(draft_prompt)

--- a/frontend/src/components/ChatHistorySidebar.vue
+++ b/frontend/src/components/ChatHistorySidebar.vue
@@ -68,6 +68,7 @@
 <script>
 import { ref, watch, nextTick } from 'vue'
 import { useUserChatStore } from '@/stores/userChatStore'
+import { parseBackendDate } from '@/utils/dateTime'
 
 export default {
   name: 'ChatHistorySidebar',
@@ -188,8 +189,7 @@ export default {
     // Päivämäärän muotoilu (tänään, eilen, muuten pvm)
     formatDate(dateString) {
       if (!dateString) return '';
-      const correctedDateString = dateString.endsWith('Z') ? dateString : dateString + 'Z';
-      const date = new Date(correctedDateString);
+      const date = parseBackendDate(dateString);
       const today = new Date();
       const yesterday = new Date();
       yesterday.setDate(today.getDate() - 1);

--- a/frontend/src/components/ChatPreviewModal.vue
+++ b/frontend/src/components/ChatPreviewModal.vue
@@ -68,6 +68,7 @@
 <script setup>
 import AppButton from "@/components/ui/AppButton.vue"
 import { useI18n } from "vue-i18n"
+import { parseBackendDate } from "@/utils/dateTime"
 
 defineProps({
   chat: Object
@@ -80,7 +81,7 @@ function formatTime(date) {
 
   const lang = locale.value === "fi" ? "fi-FI" : "en-US"
 
-  return new Date(date).toLocaleTimeString(lang, {
+  return parseBackendDate(date).toLocaleTimeString(lang, {
     hour: "2-digit",
     minute: "2-digit"
   })

--- a/frontend/src/components/chat/Chat.vue
+++ b/frontend/src/components/chat/Chat.vue
@@ -101,8 +101,8 @@
       </section>
 
       <ChatMessage
-        v-for="message in messages"
-        :key="message.id"
+        v-for="(message, index) in messages"
+        :key="messageKey(message, index)"
         :from="message.sender"
         :showLabel="message.sender !== 'user'"
         :text="message.content"
@@ -350,6 +350,10 @@ export default {
       }
     }
 
+    const messageKey = (message, index) => {
+      return `${message?.id || message?._id || message?.created_at || "message"}-${index}`
+    }
+
     return {
       t,
       chatStore,
@@ -362,6 +366,7 @@ export default {
       showForm,
       scrollToBottom,
       handleSendFromInputBar,
+      messageKey,
       triggerAuthModal,
     }
   },

--- a/frontend/src/utils/dateTime.js
+++ b/frontend/src/utils/dateTime.js
@@ -1,0 +1,14 @@
+const TIMEZONE_SUFFIX_PATTERN = /(Z|[+-]\d{2}:?\d{2})$/i
+const HAS_TIME_PATTERN = /[T ]\d{2}:\d{2}/
+
+export function parseBackendDate(value) {
+  if (!value) return null
+  if (value instanceof Date) return value
+
+  if (typeof value === "string" && HAS_TIME_PATTERN.test(value) && !TIMEZONE_SUFFIX_PATTERN.test(value)) {
+    return new Date(`${value}Z`)
+  }
+
+  return new Date(value)
+}
+

--- a/frontend/src/views/ProfessionalChatView.vue
+++ b/frontend/src/views/ProfessionalChatView.vue
@@ -28,8 +28,8 @@
             ref="messagesContainer"
             >
             <ChatMessage
-              v-for="msg in chat.messages.filter(m => m.sender !== 'info')"
-              :key="msg.id"
+              v-for="(msg, index) in visibleMessages"
+              :key="messageKey(msg, index)"
               :from="msg.sender"
               :showLabel="true"
               :side="msg.sender === 'user' ? 'left' : 'right'"
@@ -216,6 +216,13 @@ const closedToday = computed(() => chatStore.getClosedChats)
 
 // tarkistaa onko keskustelu suljettu
 const isClosed = computed(() => chat.value?.status === "closed")
+const visibleMessages = computed(() => {
+  return (chat.value?.messages || []).filter(m => m.sender !== 'info')
+})
+
+function messageKey(message, index) {
+  return `${message?.id || message?._id || message?.created_at || "message"}-${index}`
+}
 
 // vaihtaa vastauskentän muokkaustilan
 function toggleEdit() {

--- a/frontend/src/views/ProfessionalView.vue
+++ b/frontend/src/views/ProfessionalView.vue
@@ -154,6 +154,7 @@ import AppButton from "@/components/ui/AppButton.vue"
 import ChatPreviewModal from "@/components/ChatPreviewModal.vue"
 import { useAuthStore } from "@/stores/authStore"
 import { useI18n } from "vue-i18n"
+import { parseBackendDate } from "@/utils/dateTime"
 const { locale } = useI18n()
 
 // käyttäjän sessio ja tiedot
@@ -257,7 +258,7 @@ function formatTime(date) {
 
   const lang = locale.value === "fi" ? "fi-FI" : "en-US"
 
-  return new Date(date).toLocaleTimeString(lang, {
+  return parseBackendDate(date).toLocaleTimeString(lang, {
     hour: "2-digit",
     minute: "2-digit"
   })


### PR DESCRIPTION
Fix language handling, chat rendering and timezone

- Prevented RAG answers from changing language because of appended patient info.
- Added Finnish/English fallback messages when no relevant RAG context is found.
- Kept uncertain language cases flexible while still telling the model to ignore metadata when choosing the response language.
- Fixed chat rendering crashes caused by unstable or missing message IDs.
- Added safer message keys in both patient and professional chat views.
- Moved professional message filtering from the template into a computed value.
- Fix chat queue timestamp timezone handling
