### PR TITLE
fixed chat side for professional chat messages.

### DIFF
--- a/frontend/src/components/chat/ChatMessage.vue
+++ b/frontend/src/components/chat/ChatMessage.vue
@@ -536,9 +536,6 @@ function formatPages(pages) {
 
 
 /* Professional message */
-.message.professional {
-  justify-content: flex-start;
-}
 
 .message.professional .bubble {
   background: #e8f5e9;


### PR DESCRIPTION
Small css change to remove css block that overwrited another piece of code. Fixes professional chats being on the left side for the professional